### PR TITLE
Fix missing springWorker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,7 +22,6 @@ Thumbs.db
 .vscode/
 
 # Public folder
-/public/
 
 /src/dev-dist/
 # Playwright

--- a/MASTER_TASKLIST.md
+++ b/MASTER_TASKLIST.md
@@ -89,6 +89,7 @@ stretchy-face-app/
 2. **WASM Proof‑of‑Concept** – swap in a Rust/WASM spring simulator for faster performance on low‑end devices.
 3. **Adaptive Quality** – detect device performance and lower segment count or texture resolution automatically.
 4. **Analytics & Error‑Tracking** – integrate Plausible or Google Analytics and add Sentry for capturing JS errors.
+5. **Include Worker in Build** – ensure `springWorker.js` is copied to `dist/workers/` during the Vite build.
 
 ### Development Workflow
 1. **GitHub Repo** – push all code to GitHub.

--- a/public/workers/springWorker.js
+++ b/public/workers/springWorker.js
@@ -1,0 +1,26 @@
+self.onmessage = (e) => {
+  const { dt, positions, originalPos, velocities, lockedVerts, kStiff, damping } = e.data;
+  if (!positions || !originalPos || !velocities || !dt) return;
+  const pos = positions;
+  const vertCount = pos.length / 3;
+  for (let i = 0; i < vertCount; i++) {
+    const idx = i * 3;
+    if (lockedVerts && lockedVerts[i]) {
+      velocities[idx] = velocities[idx + 1] = velocities[idx + 2] = 0;
+      continue;
+    }
+    const dx = pos[idx] - originalPos[idx];
+    const dy = pos[idx + 1] - originalPos[idx + 1];
+    const dz = pos[idx + 2] - originalPos[idx + 2];
+    const fx = -kStiff * dx - damping * velocities[idx];
+    const fy = -kStiff * dy - damping * velocities[idx + 1];
+    const fz = -kStiff * dz - damping * velocities[idx + 2];
+    velocities[idx] += fx * dt;
+    velocities[idx + 1] += fy * dt;
+    velocities[idx + 2] += fz * dt;
+    pos[idx] += velocities[idx] * dt;
+    pos[idx + 1] += velocities[idx + 1] * dt;
+    pos[idx + 2] += velocities[idx + 2] * dt;
+  }
+  self.postMessage({ positions: pos, velocities });
+};


### PR DESCRIPTION
## Summary
- keep `public/` in git and add `public/workers/springWorker.js`
- note worker build step in MASTER_TASKLIST

## Testing
- `npm test`
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6882afdda8e8832c9ea805f9c40d9983