### PR TITLE
Add explicit wait for hidden upload container

### DIFF
--- a/tests/e2e/upload.spec.js
+++ b/tests/e2e/upload.spec.js
@@ -10,6 +10,7 @@ test('image upload works', async ({ page }) => {
   await page.addInitScript(() => localStorage.setItem('instructionsSeen', 'yes'));
   await page.goto('/');
   await page.setInputFiles('#upload', imagePath);
+  await page.waitForSelector('#upload-container.hidden', { state: 'hidden' });
   await page.waitForSelector('canvas#c');
   await expect(page.locator("#upload-container")).toHaveClass(/hidden/, { timeout: 10000 });
   // canvas should be visible after upload


### PR DESCRIPTION
## Summary
- wait for hidden upload container with Playwright selector

## Testing
- `npm run test:e2e`

------
https://chatgpt.com/codex/tasks/task_e_6882b4847c58832ca99fe321c414dd6a