### PR TITLE
Fix face detection alert blocking manual crop

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,13 +75,10 @@ npm test
 
 ### Handling `[ERR_FD_002]`
 
-This error appears when the app can't find a face in the uploaded image. Common
-causes include a side profile photo or the browser failing to download the face
-detection model because you're offline. Try these steps:
-
-1. Use the manual cropper to highlight your face and run detection again.
-2. Ensure your network connection is working so TensorFlow can load the model
-   files.
+This error appears when the app can't find a face in the uploaded image. If it
+occurs, the manual cropper automatically opens so you can select the face region
+yourself. If you continue to see this message, check that your network
+connection is working so TensorFlow can download the model files.
 
 ## Keyboard Controls
 

--- a/src/utils/faceDetection.js
+++ b/src/utils/faceDetection.js
@@ -80,8 +80,8 @@ export async function detectFace(imageElementOrCanvas) {
         height: box.yMax - box.yMin,
       };
     } catch (error) {
-      if (error.message.includes('No face detected') && typeof alert === 'function') {
-        alert('No face detected in the image. Ensure the face is clearly visible and try cropping manually.');
+      if (error.message.includes('No face detected')) {
+        console.warn('No face detected in the image. Falling back to manual cropping.');
       }
       if (error.message.includes('WebGL')) {
         throw new Error(`[ERR_FD_005] WebGL error: ${error.message}`);


### PR DESCRIPTION
## Summary
- log a console warning instead of blocking the UI when no face is detected
- clarify README instructions for `[ERR_FD_002]`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6882b5ac4a84832cb871aa0cc45dd986