### PR TITLE
Add performance stats toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -90,14 +90,22 @@
       New Photo
     </button>
     <!-- Theme toggle button -->
-    <button
-      id="theme-toggle"
-      title="Toggle dark mode"
-      aria-label="Dark Mode"
-    >
-      Dark Mode
-    </button>
-    <script type="module" src="src/main.js"></script>
+      <button
+        id="theme-toggle"
+        title="Toggle dark mode"
+        aria-label="Dark Mode"
+      >
+        Dark Mode
+      </button>
+      <button
+        id="stats-toggle"
+        class="hidden"
+        title="Toggle FPS stats"
+        aria-label="Show Stats"
+      >
+        Show Stats
+      </button>
+      <script type="module" src="src/main.js"></script>
     </main>
   </body>
 </html>

--- a/src/index.html
+++ b/src/index.html
@@ -32,6 +32,8 @@
   </div>
   <!-- Theme toggle button -->
   <button id="theme-toggle" title="Toggle dark mode" aria-label="Dark Mode">Dark Mode</button>
+  <!-- Stats toggle button, hidden in production -->
+  <button id="stats-toggle" class="hidden" title="Toggle FPS stats" aria-label="Show Stats">Show Stats</button>
   <script type="module" src="./main.js"></script>
   </main>
 </body>

--- a/src/main.js
+++ b/src/main.js
@@ -28,6 +28,8 @@ import { generateShareLink, loadSharedImage } from "./utils/shareLink.js";
 import { initLoadingIndicator } from "./ui/loadingIndicator.js";
 import { initInstructions } from "./ui/instructions.js";
 import { initThemeToggle } from "./ui/themeToggle.js";
+import { initStatsToggle } from "./ui/statsToggle.js";
+import Stats from "stats.js";
 import { createDefaultGrabPoints } from "./utils/grabPoints.js";
 import { initPointerControls } from "./ui/pointerControls.js";
 import { createCameraController } from "./utils/cameraController.js";
@@ -68,6 +70,7 @@ const resetButton = document.getElementById("reset-btn");
 const shareButton = document.getElementById("share-btn");
 const linkButton = document.getElementById("link-btn");
 const reuploadButton = document.getElementById("reupload-btn");
+const statsToggleButton = document.getElementById("stats-toggle");
 let resetControl;
 let shareControl;
 let linkControl;
@@ -75,6 +78,8 @@ let reuploadControl;
 let instructionsControl;
 let uploadControl;
 let themeControl;
+let statsToggleControl;
+let stats;
 
 // Helper functions for loading state are provided by loadingIndicator
 
@@ -129,6 +134,14 @@ function showReuploadButton() {
 
 function hideReuploadButton() {
   if (reuploadButton) reuploadButton.classList.add("hidden");
+}
+
+function showStatsButton() {
+  if (statsToggleButton) statsToggleButton.classList.remove("hidden");
+}
+
+function hideStatsButton() {
+  if (statsToggleButton) statsToggleButton.classList.add("hidden");
 }
 
 async function init(startFile = null) {
@@ -296,6 +309,7 @@ function proceedWithCroppedImage(img, bbox) {
             hideShareButton();
             hideLinkButton();
             hideReuploadButton();
+            hideStatsButton();
             // No page reload needed now
             // window.location.reload();
           } catch (error) {
@@ -389,6 +403,7 @@ function setupKeyboard(grabPoints) {
       hideShareButton();
       hideLinkButton();
       hideReuploadButton();
+      hideStatsButton();
     },
     grabPoints,
   });
@@ -408,10 +423,12 @@ function animate(now) {
     lastTime = 0; // Reset time to indicate loop stopped
     return;
   }
+  if (stats) stats.begin();
   const dt = (now - lastTime) / 1000;
   updateSprings(Math.min(dt, 0.1)); // Clamp dt to avoid instability
   if (indicatorControl) indicatorControl.update();
   renderer.render(scene, camera);
+  if (stats) stats.end();
   lastTime = now;
   requestAnimationFrame(animate);
 }
@@ -493,6 +510,15 @@ function startApp() {
   });
   instructionsControl = initInstructions();
   themeControl = initThemeToggle();
+  if (process.env.NODE_ENV !== "production") {
+    stats = new Stats();
+    stats.showPanel(0);
+    document.body.appendChild(stats.dom);
+    statsToggleControl = initStatsToggle(stats);
+    showStatsButton();
+  } else {
+    hideStatsButton();
+  }
   hideResetButton();
   hideShareButton();
   hideLinkButton();

--- a/src/style.css
+++ b/src/style.css
@@ -255,6 +255,24 @@ body {
 #theme-toggle:hover {
   background: linear-gradient(90deg, #fc5c7d 0%, #6a82fb 100%);
 }
+#stats-toggle {
+  position: absolute;
+  top: 1rem;
+  right: 6rem;
+  font-size: 0.9rem;
+  padding: 0.4rem 0.8rem;
+  border: none;
+  border-radius: 7px;
+  background: linear-gradient(90deg, #6a82fb 0%, #fc5c7d 100%);
+  color: #fff;
+  font-weight: 600;
+  cursor: pointer;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
+  z-index: 30;
+}
+#stats-toggle:hover {
+  background: linear-gradient(90deg, #fc5c7d 0%, #6a82fb 100%);
+}
 #share-btn:hover {
   background: linear-gradient(90deg, #fc5c7d 0%, #6a82fb 100%);
 }
@@ -332,7 +350,8 @@ body {
 
   #reset-btn,
   #share-btn,
-  #link-btn {
+  #link-btn,
+  #stats-toggle {
     bottom: 0.5rem;
     padding: 0.6rem 1.2rem;
     font-size: 1rem;

--- a/src/tests/statsToggle.test.js
+++ b/src/tests/statsToggle.test.js
@@ -1,0 +1,31 @@
+import { initStatsToggle } from '../ui/statsToggle.js';
+
+describe('stats toggle UI', () => {
+  test('click toggles stats visibility', () => {
+    document.body.innerHTML = '<button id="stats-toggle"></button>';
+    const stats = { dom: document.createElement('div') };
+    document.body.appendChild(stats.dom);
+    const ctrl = initStatsToggle(stats);
+    const btn = document.getElementById('stats-toggle');
+
+    expect(stats.dom.style.display).toBe('');
+    expect(btn.textContent).toMatch(/Hide/);
+
+    btn.click();
+    expect(stats.dom.style.display).toBe('none');
+    expect(btn.textContent).toMatch(/Show/);
+
+    btn.click();
+    expect(stats.dom.style.display).toBe('block');
+    expect(btn.textContent).toMatch(/Hide/);
+
+    ctrl.destroy();
+  });
+
+  test('handles missing button gracefully', () => {
+    const stats = { dom: document.createElement('div') };
+    const ctrl = initStatsToggle(stats);
+    expect(ctrl).toHaveProperty('destroy');
+    ctrl.destroy();
+  });
+});

--- a/src/ui/statsToggle.js
+++ b/src/ui/statsToggle.js
@@ -1,0 +1,29 @@
+export function initStatsToggle(stats) {
+  const btn = document.getElementById('stats-toggle');
+  if (!btn || !stats) {
+    return { destroy() {} };
+  }
+
+  let visible = true;
+
+  const update = () => {
+    const text = visible ? 'Hide Stats' : 'Show Stats';
+    btn.textContent = text;
+    btn.setAttribute('aria-label', text);
+  };
+
+  const toggle = () => {
+    visible = !visible;
+    stats.dom.style.display = visible ? 'block' : 'none';
+    update();
+  };
+
+  btn.addEventListener('click', toggle);
+  update();
+
+  return {
+    destroy() {
+      btn.removeEventListener('click', toggle);
+    }
+  };
+}


### PR DESCRIPTION
## Summary
- display FPS panel in development
- allow showing/hiding the performance panel
- test the new stats toggle

## Testing
- `npm run lint`
- `npm test`
- `npm run test:e2e` *(fails: missing host dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6882d1b1aecc832c898e194b96259fb6