### PR TITLE
Add performance stats toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -97,6 +97,14 @@
     >
       Dark Mode
     </button>
+    <!-- Stats toggle button -->
+    <button
+      id="stats-toggle"
+      title="Show performance stats"
+      aria-label="Show performance stats"
+    >
+      Show Stats
+    </button>
     <script type="module" src="src/main.js"></script>
     </main>
   </body>

--- a/src/main.js
+++ b/src/main.js
@@ -34,6 +34,8 @@ import { createCameraController } from "./utils/cameraController.js";
 import { initGrabIndicators } from "./ui/grabIndicators.js";
 import { initAnalytics, installGlobalErrorHandlers, logError } from "./utils/analytics.js";
 import { assertBackendHealthy } from "./utils/backendChecks.js";
+import Stats from "stats.js";
+import { initStatsToggle } from "./ui/statsToggle.js";
 
 // Error codes:
 // ERR_IN_001: Initialization failed
@@ -75,6 +77,8 @@ let reuploadControl;
 let instructionsControl;
 let uploadControl;
 let themeControl;
+let stats;
+let statsControl;
 
 // Helper functions for loading state are provided by loadingIndicator
 
@@ -408,10 +412,12 @@ function animate(now) {
     lastTime = 0; // Reset time to indicate loop stopped
     return;
   }
+  if (stats) stats.begin();
   const dt = (now - lastTime) / 1000;
   updateSprings(Math.min(dt, 0.1)); // Clamp dt to avoid instability
   if (indicatorControl) indicatorControl.update();
   renderer.render(scene, camera);
+  if (stats) stats.end();
   lastTime = now;
   requestAnimationFrame(animate);
 }
@@ -493,6 +499,11 @@ function startApp() {
   });
   instructionsControl = initInstructions();
   themeControl = initThemeToggle();
+  if (process.env.NODE_ENV !== 'production') {
+    stats = new Stats();
+    stats.showPanel(0);
+    statsControl = initStatsToggle(stats);
+  }
   hideResetButton();
   hideShareButton();
   hideLinkButton();

--- a/src/style.css
+++ b/src/style.css
@@ -255,6 +255,24 @@ body {
 #theme-toggle:hover {
   background: linear-gradient(90deg, #fc5c7d 0%, #6a82fb 100%);
 }
+#stats-toggle {
+  position: absolute;
+  top: 3.5rem;
+  right: 1rem;
+  font-size: 0.9rem;
+  padding: 0.4rem 0.8rem;
+  border: none;
+  border-radius: 7px;
+  background: linear-gradient(90deg, #6a82fb 0%, #fc5c7d 100%);
+  color: #fff;
+  font-weight: 600;
+  cursor: pointer;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
+  z-index: 30;
+}
+#stats-toggle:hover {
+  background: linear-gradient(90deg, #fc5c7d 0%, #6a82fb 100%);
+}
 #share-btn:hover {
   background: linear-gradient(90deg, #fc5c7d 0%, #6a82fb 100%);
 }

--- a/src/tests/statsToggle.test.js
+++ b/src/tests/statsToggle.test.js
@@ -1,0 +1,17 @@
+import { initStatsToggle } from '../ui/statsToggle.js';
+
+describe('stats toggle', () => {
+  test('toggles panel visibility', () => {
+    document.body.innerHTML = '<button id="stats-toggle"></button>';
+    const fakeStats = { dom: document.createElement('div') };
+    const ctrl = initStatsToggle(fakeStats);
+    const btn = document.getElementById('stats-toggle');
+    expect(fakeStats.dom.style.display).toBe('none');
+    btn.click();
+    expect(fakeStats.dom.style.display).toBe('block');
+    expect(btn.textContent).toBe('Hide Stats');
+    btn.click();
+    expect(fakeStats.dom.style.display).toBe('none');
+    ctrl.destroy();
+  });
+});

--- a/src/ui/statsToggle.js
+++ b/src/ui/statsToggle.js
@@ -1,0 +1,45 @@
+export function initStatsToggle(stats) {
+  const btn = document.getElementById('stats-toggle');
+  if (!btn || !stats) {
+    return { destroy() {} };
+  }
+
+  let visible = false;
+  const panel = stats.dom;
+  panel.style.position = 'absolute';
+  panel.style.top = '0';
+  panel.style.left = '0';
+  panel.style.zIndex = '60';
+  panel.style.display = 'none';
+
+  function update() {
+    panel.style.display = visible ? 'block' : 'none';
+    const text = visible ? 'Hide Stats' : 'Show Stats';
+    btn.textContent = text;
+    btn.setAttribute('aria-label', text);
+  }
+
+  const toggle = () => {
+    visible = !visible;
+    update();
+  };
+
+  btn.addEventListener('click', toggle);
+  document.body.appendChild(panel);
+  update();
+
+  return {
+    destroy() {
+      btn.removeEventListener('click', toggle);
+      if (panel.parentNode) panel.parentNode.removeChild(panel);
+    },
+    show() {
+      visible = true;
+      update();
+    },
+    hide() {
+      visible = false;
+      update();
+    },
+  };
+}


### PR DESCRIPTION
## Summary
- import `stats.js` and stats toggle module
- display stats panel when not in production
- implement `initStatsToggle` helper
- style and add button to toggle stats
- test stats toggle behavior

## Testing
- `npm ci`
- `npm test`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6882d1b1aecc832c898e194b96259fb6